### PR TITLE
Feature/162 blockchain link

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ The cache script will gather all immutable information from the ethereum network
 
 `yarn build-cache`
 
-To understand a bit better what the script will do you can see `scripts/builCache.sh` and `scripts/buildCache.ts`.
+To understand a bit better what the script will do you can see `scripts/buildCache.sh` and `scripts/buildCache.ts`.
 
 ### Configuration
 

--- a/src/components/common/BlockchainLink.tsx
+++ b/src/components/common/BlockchainLink.tsx
@@ -1,8 +1,9 @@
 import styled from 'styled-components';
 import Copy from './Copy';
-import { getBlockchainLink } from '../../utils';
+import { getBlockchainLink, getENSName, getERC20Token, getDxVoteContract, toAddressStub} from 'utils';
 import { useContext } from '../../contexts';
 import { FiExternalLink } from 'react-icons/fi';
+import { useEffect, useState } from 'react';
 
 const AddressLink = styled.span`
   display: flex;
@@ -31,24 +32,25 @@ const BlockchainLink = ({
 
   const networkName = configStore.getActiveChainName();
 
-  function formarText(toFormat) {
-    const start = toFormat.slice(0, 6);
-    const end = toFormat.slice(-4);
-
-    switch (size) {
-      case 'short':
-        return `${start}..`;
-      case 'long':
-        return toFormat;
-      default:
-        return `${start}...${end}`;
+  const [ensName, setENSName] = useState(''); 
+  const erc20Token = getERC20Token(text);
+  const dxVoteContract = getDxVoteContract(text)
+  
+  useEffect(() => {
+    async function getENS() {
+      const response = await getENSName(text);
+      setENSName(response);
     }
-  }
-
+    getENS();
+  }, [])
+  
   return (
     <AddressLink>
       <a href={getBlockchainLink(text, networkName, type)} target="_blank">
-        {onlyIcon ? <FiExternalLink /> : formarText(text)}
+        {onlyIcon ? <FiExternalLink /> : toAddressStub(text, size)}
+        {ensName}
+        {erc20Token}
+        {dxVoteContract?.contract}
       </a>
       {toCopy ? <Copy toCopy={text} /> : <div />}
     </AddressLink>
@@ -56,3 +58,10 @@ const BlockchainLink = ({
 };
 
 export default BlockchainLink;
+
+
+/*
+If the address is an ERC20 token registered in the config show the token symbol instead with links to the token explorer, and the option to copy the token address.
+If the address is an ens domain show the ens domain name with a link to the blockchain explorer address and option to copy the address.
+If the address is an known dxvote contract (avatar,controller, etc) domain show the contract name with a link to the blockchain explorer address and option to copy the address.
+*/

--- a/src/components/common/Transaction.tsx
+++ b/src/components/common/Transaction.tsx
@@ -1,5 +1,6 @@
 import styled from 'styled-components';
 import { useContext } from '../../contexts';
+import { toAddressStub } from 'utils';
 
 const AddressLink = styled.a`
   padding: 2px 5px;
@@ -17,20 +18,7 @@ const UserAddress = ({ address, size = 'default', type = 'default' }) => {
 
   const networkName = configStore.getActiveChainName();
 
-  function toAddressStub(address) {
-    const start = address.slice(0, 6);
-    const end = address.slice(-4);
-
-    switch (size) {
-      case 'short':
-        return `${start}..`;
-      case 'long':
-        return address;
-      default:
-        return `${start}...${end}`;
-    }
-  }
-
+  
   function href() {
     switch (type) {
       case 'user':
@@ -42,7 +30,7 @@ const UserAddress = ({ address, size = 'default', type = 'default' }) => {
     }
   }
 
-  return <AddressLink href={href()}>{toAddressStub(address)}</AddressLink>;
+  return <AddressLink href={href()}>{toAddressStub(address, size)}</AddressLink>;
 };
 
 export default UserAddress;

--- a/src/utils/address.ts
+++ b/src/utils/address.ts
@@ -1,4 +1,5 @@
 import { ethers, utils } from 'ethers';
+const appConfig = require('../config.json');
 
 export function shortenAddress(address, digits = 4) {
   if (!isAddress(address)) {
@@ -21,8 +22,80 @@ export function toChecksum(address) {
   return utils.getAddress(address);
 }
 
-export function toAddressStub(address) {
-  const start = address.slice(0, 5);
-  const end = address.slice(-3);
-  return `${start}...${end}`;
+export function toAddressStub(address, size = 'default') {
+  const start = address.slice(0, 6);
+  const end = address.slice(-4);
+
+  switch (size) {
+    case 'short':
+      return `${start}..`;
+    case 'long':
+      return address;
+    default:
+      return `${start}...${end}`;
+  }
+}
+
+export function getBlockchainLink(address, networkName, type) {
+  switch (type) {
+    case 'user':
+      return `${window.location.pathname}#/user/${address}`;
+    case 'address':
+      if (networkName === 'arbitrum')
+        return `https://explorer.arbitrum.io/#/address/${address}`;
+      else if (networkName === 'arbitrumTestnet')
+        return `https://rinkeby-explorer.arbitrum.io/#/address/${address}`;
+      else if (networkName === 'mainnet')
+        return `https://etherscan.io/address/${address}`;
+      else if (networkName === 'xdai')
+        return `https://blockscout.com/xdai/mainnet/address/${address}`;
+      else return `https://${networkName}.etherscan.io/address/${address}`;
+    default: // investigate DRY here
+      if (networkName === 'arbitrum')
+        return `https://explorer.arbitrum.io/#/tx/${address}`;
+      else if (networkName === 'arbitrumTestnet')
+        return `https://rinkeby-explorer.arbitrum.io/#/tx/${address}`;
+      else if (networkName === 'mainnet')
+        return `https://etherscan.io/tx/${address}`;
+      else if (networkName === 'xdai')
+        return `https://blockscout.com/xdai/mainnet/tx/${address}`;
+      else return `https://${networkName}.etherscan.io/tx/${address}`;
+  }
+}
+
+export async function getENSName(address) {
+  let name = null;
+  try {
+    const provider = ethers.getDefaultProvider();
+    let checksumed = ethers.utils.getAddress(address);
+    name = provider.lookupAddress(checksumed);
+  }
+  catch (e) {
+    console.error(e);
+  }
+  return name;
+} 
+
+export function getERC20Token(address) {
+  let tokenObject;
+  Object.keys(appConfig).forEach((network => {
+    tokenObject = appConfig[network]?.tokens?.filter(token => token.address === address)
+    if (tokenObject) return;
+  }));
+  return tokenObject;
+}
+
+export function getDxVoteContract(address) {
+  let obj = null;
+  Object.keys(appConfig).forEach(network => {
+    let contracts = appConfig[network]?.contracts
+    for (let [key, value] of Object.entries(contracts)) {
+      if (value === address) {
+        obj = {contract: key, address: value}
+        return;
+      }
+    }
+    return;
+  });
+  return obj;
 }

--- a/src/utils/helpers.ts
+++ b/src/utils/helpers.ts
@@ -62,29 +62,3 @@ export function parseCamelCase(text) {
   return parsed[0].toUpperCase() + parsed.substring(1);
 }
 
-export function getBlockchainLink(text, networkName, type) {
-  switch (type) {
-    case 'user':
-      return `${window.location.pathname}#/user/${text}`;
-    case 'address':
-      if (networkName === 'arbitrum')
-        return `https://explorer.arbitrum.io/#/address/${text}`;
-      else if (networkName === 'arbitrumTestnet')
-        return `https://rinkeby-explorer.arbitrum.io/#/address/${text}`;
-      else if (networkName === 'mainnet')
-        return `https://etherscan.io/address/${text}`;
-      else if (networkName === 'xdai')
-        return `https://blockscout.com/xdai/mainnet/address/${text}`;
-      else return `https://${networkName}.etherscan.io/address/${text}`;
-    default:
-      if (networkName === 'arbitrum')
-        return `https://explorer.arbitrum.io/#/tx/${text}`;
-      else if (networkName === 'arbitrumTestnet')
-        return `https://rinkeby-explorer.arbitrum.io/#/tx/${text}`;
-      else if (networkName === 'mainnet')
-        return `https://etherscan.io/tx/${text}`;
-      else if (networkName === 'xdai')
-        return `https://blockscout.com/xdai/mainnet/tx/${text}`;
-      else return `https://${networkName}.etherscan.io/tx/${text}`;
-  }
-}


### PR DESCRIPTION
Done: 
- added utils methods for: 
a) getENSName(address)
b) getERC20token(address)
c) getDxVoteContract(address)
- refactored repeated implementation of addressStub function and move to helpers. 
- implemented an async call in mount for the component to call helper for check for ENS name resolution. 

WIP: 
refactor the way the BlockchainLink presents the info in the component such that: 
if a) show ens name with link to address explorer, and an icon to copy address. 
if b) show token token symbol with link to token explorer, and icon to copy address. 
if c) show contract name with link to address explorer, and icon to copy address. 

Rethink the way this component is used to define the correct props regarding use cases in the page components.  
